### PR TITLE
Tab persistence and permission fix

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -256,6 +256,9 @@ class _NavBarState extends State<NavBar> {
   void onTabTapped(int index) {
     setState(() {
       _currentIndex = index;
+      if (index == 2) {
+        History();
+      }
     });
   }
 }

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -610,12 +610,6 @@ class _SettingsState extends State<Settings> {
   }
 
   Future loadAsync(BuildContext context) async {
-    await [
-      Permission.storage,
-      Permission.manageExternalStorage,
-      Permission.ignoreBatteryOptimizations,
-    ].request();
-
     final prefs = await SharedPreferences.getInstance();
     final requrl = prefs.getString('requrl');
     final resprop = prefs.getString('resprop');


### PR DESCRIPTION
**Changes**
- The tab "History" now reloads every time the tab gets selected
- Fixed an error with permissions on startup, where different permission requests interfered with each other